### PR TITLE
:bookmark: bump version 0.2.1 -> 0.3.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.13
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.2.1
+current_version: 0.3.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.3.0]
+
 ### Added
 
 - Added the `page_date_range` argument to the `DatePaginator`, taking the place of the existing `date_range` argument. This change clarifies that it represents constraining the range of dates for each page, not the entire range of dates for the paginator.
@@ -64,7 +66,9 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.2.1...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox.git/compare/v0.3.0...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
+
+[0.3.0]: https://github.com/westerveltco/django-twc-toolbox.git/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ Source = "https://github.com/westerveltco/django-twc-toolbox"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.2.1"
+current_version = "0.3.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 __template_version__ = "2024.13"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.2.1"
+    assert __version__ == "0.3.0"


### PR DESCRIPTION
- `9b500a9`: move `DatePage` properties to actual `cached_property` on class (#13)
- `21aae40`: rename `date_range` to `page_date_range` on `DatePaginator` (#12)
- `fa4c1ec`: update CHANGELOG
- `69994ef`: update CHANGELOG
- `312162f`: split inherited paginator test into separate test class (#14)
- `b9213d1`: add warning when `orphans` passed into `DatePaginator` (#16)
- `f03d80f`: fix heading links in CHANGELOG
- `3370b7f`: refactor getting object list for page (#17)
- `2c7c8ad`: [pre-commit.ci] pre-commit autoupdate (#3)
- `3394dc6`: add docs (#19)
- `8ed0701`: update repo using `django-twc-package` template (#20)
- `da4515a`: bump template to 2024.10 (#22)
- `2a9690d`: bump template to v2024.13 (#23)