### PR TITLE
:bookmark: bump version 0.3.1 -> 0.4.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.3.1
+current_version: 0.4.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
 
 -   Added a `CuidField` and extra dependencies needed to use it. Install the package with `django-twc-toolbox[cuid]` in order to use it.
@@ -84,9 +86,10 @@ Initial release!
 
 -   Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.3.1...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.4.0...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
 [0.3.0]: https://github.com/westerveltco/django-twc-toolbox.git/releases/tag/v0.3.0
 [0.3.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.3.1
+[0.4.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ Source = "https://github.com/westerveltco/django-twc-toolbox"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.3.1"
+current_version = "0.4.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.1"
+    assert __version__ == "0.4.0"


### PR DESCRIPTION
- `9565dcc`: add `CuidField` and extras needed (#33)
- `870277a`: drop support for Django 3.2 (#35)
- `5e971da`: [pre-commit.ci] pre-commit autoupdate (#26)