### PR TITLE
:bookmark: bump version 0.6.0 -> 0.7.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.6.0
+current_version: 0.7.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Added
 
 - Added `list_templates` management command, inspired by [this post](https://noumenal.es/notes/tailwind/django-integration/) from Carlton Gibson ([@carltongibson](https://github.com/carltongibson)).
@@ -106,7 +108,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.7.0...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
@@ -115,3 +117,4 @@ Initial release!
 [0.4.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.4.0
 [0.5.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.5.0
 [0.6.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.6.0
+[0.7.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ Source = "https://github.com/westerveltco/django-twc-toolbox"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.6.0"
+current_version = "0.7.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.6.0"
+    assert __version__ == "0.7.0"


### PR DESCRIPTION
- `de4eaf3`: move types module to private and add various pyright ignore rules (#44)
- `c93c81a`: add `list_templates` management command (#47)
- `e86ade7`: allow `createsuperuser` to reset email field (#49)
- `252ac87`: add `copy_template` management command (#48)
- `5c99a9c`: add various templatetags (#50)
- `993d1ec`: [pre-commit.ci] pre-commit autoupdate (#46)
- `08c1082`: add `ruff` to dev extras (#51)
- `3f06cf1`: update changelog
- `31d970f`: add Sentry sampling helper functions (#52)