### PR TITLE
fix check for `request.htmx` in `CRUDView.get_template_names`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected check in `django_twc_toolbox.crud.CRUDView.get_template_names` for if an `HttpRequest` is an HTMX request or not.
+
 ## [0.9.0]
 
 ### Added

--- a/src/django_twc_toolbox/crud/views.py
+++ b/src/django_twc_toolbox/crud/views.py
@@ -157,7 +157,7 @@ class CRUDView(NeapolitanCRUDView):
         # pagination links, but for now we'll just render the entire template.
         if (
             self.role == Role.LIST
-            and hasattr(self.request, "htmx")
+            and getattr(self.request, "htmx", False)
             and not self.kwargs.get(self.page_kwarg, None)  # pyright: ignore[reportAny]
             and not self.request.GET.get(self.page_kwarg, None)
         ):

--- a/tests/test_crud/test_views.py
+++ b/tests/test_crud/test_views.py
@@ -165,3 +165,34 @@ def test_get_context_data_table(klass, expected, rf, db):
     context = View(request=request).get_context_data()
 
     assert ("table" in context.keys()) is expected
+
+
+@pytest.mark.parametrize(
+    "htmx,expected",
+    [
+        (True, "neapolitan/object_list.html#object-list"),
+        (False, "neapolitan/object_list.html"),
+    ],
+)
+def test_get_template_names(htmx, expected, rf):
+    request = rf.get(Role.LIST.maybe_reverse(BookmarkView))
+    request.htmx = htmx
+
+    view = BookmarkView(role=Role.LIST, **Role.LIST.extra_initkwargs())
+    view.setup(request)
+
+    template_names = view.get_template_names()
+
+    assert expected in template_names
+
+
+def test_get_template_names_no_htmx(rf):
+    request = rf.get(Role.LIST.maybe_reverse(BookmarkView))
+
+    view = BookmarkView(role=Role.LIST, **Role.LIST.extra_initkwargs())
+    view.setup(request)
+
+    template_names = view.get_template_names()
+
+    assert "neapolitan/object_list.html" in template_names
+    assert "neapolitan/object_list.html#object-list" not in template_names


### PR DESCRIPTION
closes #68 