### PR TITLE
fix pagination and object list ordering when `table_class` is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed pagination and ordering of `CRUDView.object_list` when a `table_class` is provided.
+
 ## [0.9.2]
 
 ### Fixed

--- a/src/django_twc_toolbox/crud/views.py
+++ b/src/django_twc_toolbox/crud/views.py
@@ -90,23 +90,26 @@ class CRUDView(NeapolitanCRUDView):
         """GET handler for the list view."""
 
         queryset = self.get_queryset()
+
         filterset = self.get_filterset(queryset)
         if filterset is not None:
             queryset = filterset.qs
+
+        # set object_list up here instead of down in the `if paginate_by is None` checks
+        self.object_list = queryset
 
         if not self.allow_empty and not queryset.exists():
             raise Http404
 
         if self.table_class is not None:
-            # This is the only part that is changed from the `neapolitan.views.CRUDView` parent class.
-            #
             # If `table_class` is set, that means the view class has `SingleTableMixin` in it's inheritance
             # chain[^1]. `neapolitan.views.CRUDView.get_paginate_by` does not take an argument, whereas
             # `django_tables2.views.SingleTableMixin.get_paginate_by` expects one (`table_data`), so we need
             # to pass in an argument so the view doesn't crash.
             #
-            # Now, mind you, `SingleTableMixin.get_paginate_by` doesn't actually **do** anything with that
-            # argument, so it's a bit useless. But 🤷 whatareyagonnado?
+            # Now, mind you, `SingleTableMixin.get_paginate_by` doesn't appear actually **do** anything with
+            # that argument, so it seems like a bit of a useless thing. But 🤷 whatareyagonnado? I'm sure they
+            # have their reasons when they wrote it that way.
             #
             # I have opened an issue on neapolitan to add the ability for `CRUDView.get_paginate_by` to take
             # arbitrary args and kwargs by adding `*args, **kwargs`. I may also open an issue on django-tables2
@@ -115,13 +118,12 @@ class CRUDView(NeapolitanCRUDView):
             #
             # [^1]: Inheritance chain? Is that the correct terminology? Probably not, but you get the idea.
 
-            paginate_by = self.get_paginate_by(queryset)  # type: ignore[call-arg]  # pyright: ignore[reportCallIssue,reportUnknownVariableType]
+            paginate_by = self.get_paginate_by(self.object_list)  # type: ignore[call-arg]  # pyright: ignore[reportCallIssue,reportUnknownVariableType]
         else:
             paginate_by = self.get_paginate_by()
 
         if paginate_by is None:
             # Unpaginated response
-            self.object_list = queryset
             context = self.get_context_data(
                 page_obj=None,
                 is_paginated=False,
@@ -130,8 +132,7 @@ class CRUDView(NeapolitanCRUDView):
             )
         else:
             # Paginated response
-            page = self.paginate_queryset(queryset, paginate_by)
-            self.object_list = page.object_list
+            page = self.paginate_queryset(self.object_list, paginate_by)
             context = self.get_context_data(
                 page_obj=page,
                 is_paginated=page.has_other_pages(),

--- a/tests/test_crud/test_views.py
+++ b/tests/test_crud/test_views.py
@@ -7,6 +7,7 @@ from model_bakery import baker
 from neapolitan.views import Role
 
 from .models import Bookmark
+from .views import BookmarkTableOrderedView
 from .views import BookmarkTableView
 from .views import BookmarkView
 
@@ -196,3 +197,11 @@ def test_get_template_names_no_htmx(rf):
 
     assert "neapolitan/object_list.html" in template_names
     assert "neapolitan/object_list.html#object-list" not in template_names
+
+
+def test_table_view_ordered(client, db):
+    baker.make(Bookmark, _quantity=3)
+
+    response = client.get(Role.LIST.maybe_reverse(BookmarkTableOrderedView))
+
+    assert response.status_code == 200

--- a/tests/test_crud/views.py
+++ b/tests/test_crud/views.py
@@ -22,9 +22,23 @@ class BookmarkTable(tables.Table):
 
 class BookmarkTableView(BookmarkView):
     table_class = BookmarkTable
+    url_base = "bookmarktable"
+
+
+class BookmarkTableOrdered(tables.Table):
+    class Meta:
+        model = Bookmark
+        order_by = "title"
+
+
+class BookmarkTableOrderedView(BookmarkView):
+    table_class = BookmarkTableOrdered
+    paginate_by = 1
+    url_base = "bookmarktableordered"
 
 
 urlpatterns = [
     *BookmarkView.get_urls(),
     *BookmarkTableView.get_urls(),
+    *BookmarkTableOrderedView.get_urls(),
 ]


### PR DESCRIPTION
closes #73 