### PR TITLE
:bookmark: bump version 0.9.2 -> 0.9.3

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.9.2
+current_version: 0.9.3
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.9.3]
+
 ### Fixed
 
 - Fixed pagination and ordering of `CRUDView.object_list` when a `table_class` is provided.
@@ -149,7 +151,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.9.2...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.9.3...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
@@ -163,3 +165,4 @@ Initial release!
 [0.9.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.9.0
 [0.9.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.9.1
 [0.9.2]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.9.2
+[0.9.3]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.9.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.9.2"
+current_version = "0.9.3"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.9.2"
+    assert __version__ == "0.9.3"


### PR DESCRIPTION
- `8677652`: fix pagination and object list ordering when `table_class` is provided (#74)