### PR TITLE
:bookmark: bump version 0.10.0 -> 0.11.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.10.0
+current_version: 0.11.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.11.0]
+
 ### Added
 
 - Added support for specifying primary filters on `CRUDView` via a `filterset_primary_fields` class attribute. Sometimes you have a model and corresponding crud view that has a bunch of filters attached to it. Rather than show all filters or show none and hide them behind a 'Show Filters' button, this allows you to have a handful of primary filters with the rest of the filters set as secondary. This way, you can always show the primary filters, but hide the secondary ones.
@@ -166,7 +168,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.10.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.11.0...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
@@ -182,3 +184,4 @@ Initial release!
 [0.9.2]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.9.2
 [0.9.3]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.9.3
 [0.10.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.10.0
+[0.11.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.10.0"
+current_version = "0.11.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.10.0"
+    assert __version__ == "0.11.0"


### PR DESCRIPTION
- `32022da`: add override of `get_paginate_by` to allow for `args` and `kwargs` (#78)
- `267b158`: add support for primary filters in `CRUDView` (#79)
- `aca62e2`: add filterset extra methods for active filters in `CRUDView` (#80)