### PR TITLE
add ability to customize how detail fields are rendered

### DIFF
--- a/src/django_twc_toolbox/crud/views.py
+++ b/src/django_twc_toolbox/crud/views.py
@@ -12,6 +12,7 @@ from django.http import Http404
 from django.http import HttpRequest
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
+from django.utils.safestring import SafeString
 from django_htmx.middleware import HtmxDetails
 from django_tables2 import tables
 from django_tables2.views import SingleTableMixin
@@ -33,6 +34,8 @@ class CRUDView(NeapolitanCRUDView):
 
     detail_fields: ClassVar[list[str] | None] = None
     list_fields: ClassVar[list[str] | None] = None
+
+    detail_field_renderers: ClassVar[dict[str, Callable[..., str | SafeString]]] = {}
 
     table_class: ClassVar[type[tables.Table] | None] = None
     table_data: ClassVar[dict[str, object] | None] = None
@@ -85,6 +88,11 @@ class CRUDView(NeapolitanCRUDView):
 
     def get_list_fields(self):
         return self.list_fields
+
+    def get_detail_field_renderers(
+        self,
+    ) -> dict[str, Callable[..., str | SafeString]]:
+        return self.detail_field_renderers
 
     @override
     def list(

--- a/tests/test_crud/test_templatetags.py
+++ b/tests/test_crud/test_templatetags.py
@@ -35,6 +35,26 @@ def test_object_detail(db):
     assert detail_list[1][1] == getattr(object, view.detail_fields[1])
 
 
+def test_object_detail_with_renderer(db):
+    def render_url(**kwargs):
+        return "https://example.com"
+
+    class BookmarkDetailRendererView(BookmarkView):
+        detail_field_renderers = {
+            "url": render_url,
+        }
+
+    view = BookmarkDetailRendererView(role=Role.DETAIL)
+    object = baker.make(Bookmark)
+
+    detail = object_detail(object, view)
+    detail_list = list(detail["object"])
+
+    assert detail_list[0][0] == view.detail_fields[0]
+    assert detail_list[0][1] == "https://example.com"
+    assert detail_list[0][1] != getattr(object, view.detail_fields[0])
+
+
 def test_object_list(db):
     view = BookmarkView(role=Role.LIST)
     objects = baker.make(Bookmark, _quantity=5)


### PR DESCRIPTION
Adds a `detail_field_renderers` attribute to `CRUDView` that is a dictionary of fields to callables that return strings. Allows for customizing the rendering of certain fields in the detail view without having to resort to a custom `object_detail.html` template just for one field.