### PR TITLE
add NumberInFilter for django_filters

### DIFF
--- a/src/django_twc_toolbox/filters.py
+++ b/src/django_twc_toolbox/filters.py
@@ -1,8 +1,31 @@
 from __future__ import annotations
 
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Q
 from django_filters import BaseInFilter
+from django_filters import Filter
 from django_filters import NumberFilter
 
 
 class NumberInFilter(BaseInFilter, NumberFilter):
     pass
+
+
+class SearchFilter(Filter):
+    def __init__(self, *args, search_fields=None, **kwargs):
+        if search_fields is None:
+            raise ImproperlyConfigured("The 'search_fields' argument is required.")
+        self.search_fields = search_fields
+        super().__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        if not value:
+            return qs
+
+        value = value.strip().split(" ")
+
+        q = Q()
+        for field in self.search_fields:
+            for term in value:
+                q |= Q(**{field + "__icontains": term})
+        return qs.filter(q)


### PR DESCRIPTION
- [ ] add ability to change _how_ the search is performed
	- a simple pattern I like is defining a `search` method on either a model's custom `QuerySet` or `Manager`
	- Maybe a check for if the queryset has that method, if so call it, otherwise fall back to the simple filter like it currently is?
- [ ] some tests