### PR TITLE
:bookmark: bump version 0.15.0 -> 0.16.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.15.0
+current_version: 0.16.0
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.16.0]
+
 ### Added
 
 - A middleware `django_twc_toolbox.middleware.WwwRedirectMiddleware` for redirecting any request from a "www." subdomain to the bare domain. All credit to [Adam Johnson](https://github.com/adamchainz) -- [How to Make Django Redirect WWW to Your Bare Domain - Adam Johnson](https://adamj.eu/tech/2020/03/02/how-to-make-django-redirect-www-to-your-bare-domain/).
@@ -230,7 +232,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.15.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.16.0...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
@@ -252,3 +254,4 @@ Initial release!
 [0.13.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.13.0
 [0.14.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.14.0
 [0.15.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.15.0
+[0.16.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.15.0"
+current_version = "0.16.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.15.0"
+    assert __version__ == "0.16.0"


### PR DESCRIPTION
- `fb0e740`: [pre-commit.ci] pre-commit autoupdate (#104)
- `31b6630`: [pre-commit.ci] pre-commit autoupdate (#105)
- `5749968`: add `WwwRedirectMiddleware` for redirecting www to bare domain (#106)
- `8df1ec0`: :robot: [pre-commit.ci] pre-commit autoupdate (#108)
- `fa53eb1`: put  `WithHistory` abstract model behind `simple_history` check (#109)
- `ac65284`: bump template to v2024.27 and add support for Django 5.1 (#111)