### PR TITLE
add test to check when django-simple-history not installed

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import sys
+from unittest.mock import patch
+
 import pytest
+from django.conf import settings
+from django.test import override_settings
 from model_bakery import baker
 
 pytestmark = pytest.mark.django_db
@@ -37,3 +42,21 @@ def test_save_without_history_method():
     dummy.save_without_history()
 
     assert dummy.history.count() == 1
+
+
+@override_settings(
+    INSTALLED_APPS=[app for app in settings.INSTALLED_APPS if app != "simple_history"]
+)
+def test_without_simple_history():
+    if "django_twc_toolbox.models" in sys.modules:
+        del sys.modules["django_twc_toolbox.models"]
+
+    with patch("importlib.util.find_spec", return_value=None):
+        import django_twc_toolbox.models
+
+        assert not hasattr(django_twc_toolbox.models, "WithHistory")
+
+        assert hasattr(django_twc_toolbox.models, "TimeStamped")
+
+    if "django_twc_toolbox.models" in sys.modules:
+        del sys.modules["django_twc_toolbox.models"]


### PR DESCRIPTION
closes #110 

Also, LOL I labeled this as a "good first issue", how dumb. This took me a minute to nail down.