### PR TITLE
remove `changed_by` field from `WithHistory` abstract model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Removed
+
+- Remove `WithHistory.changed_by`. This was introduced due to a misread of the django-simply-history documentation and is unneeded.
+
 ## [0.16.1]
 
 ### Fixed

--- a/src/django_twc_toolbox/models.py
+++ b/src/django_twc_toolbox/models.py
@@ -66,16 +66,12 @@ class TimeStamped(models.Model):
 
 
 if find_spec("simple_history"):
-    from django.contrib.auth import get_user_model
-    from django.contrib.auth.models import AbstractBaseUser
     from simple_history.models import HistoricalRecords
 
     class WithHistory(models.Model):
         """
         Abstract model for adding historical records to a model.
         """
-
-        changed_by = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)
 
         history = HistoricalRecords(inherit=True)
 
@@ -94,11 +90,3 @@ if find_spec("simple_history"):
                 self.save(*args, **kwargs)
             finally:
                 del self.skip_history_when_saving
-
-        @property
-        def _history_user(self) -> AbstractBaseUser:
-            return self.changed_by
-
-        @_history_user.setter
-        def _history_user(self, user: AbstractBaseUser) -> None:
-            self.changed_by = user  # type: ignore[assignment]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.test import override_settings
 from model_bakery import baker
 
@@ -43,75 +42,6 @@ def test_save_without_history_method():
     dummy.save_without_history()
 
     assert dummy.history.count() == 1
-
-
-def test_changed_by_user():
-    user = baker.make(get_user_model())
-
-    dummy = baker.make("dummy.ModelWithHistory", changed_by=user)
-
-    assert dummy.changed_by == user
-    assert dummy.history.count() == 1
-    assert dummy.history.first().history_user == user
-
-
-def test_change_user():
-    user = baker.make(get_user_model())
-    another_user = baker.make(get_user_model())
-
-    dummy = baker.make("dummy.ModelWithHistory", changed_by=user)
-
-    assert dummy.changed_by == user
-    assert dummy.history.count() == 1
-
-    dummy.changed_by = another_user
-    dummy.save()
-
-    assert dummy.changed_by == another_user
-    assert dummy.history.count() == 2
-    assert dummy.history.first().history_user == another_user
-
-
-def test_history_user_property():
-    user = baker.make(get_user_model())
-
-    dummy = baker.make("dummy.ModelWithHistory", changed_by=user)
-
-    assert dummy._history_user == user
-
-
-def test_history_user_setter():
-    user = baker.make(get_user_model())
-    another_user = baker.make(get_user_model())
-
-    dummy = baker.make("dummy.ModelWithHistory", changed_by=user)
-
-    dummy._history_user = another_user
-    dummy.save()
-
-    assert dummy.changed_by == another_user
-    assert dummy.history.count() == 2
-    assert dummy.history.first().history_user == another_user
-
-
-def test_multiple_changes_with_different_users():
-    user = baker.make(get_user_model())
-    another_user = baker.make(get_user_model())
-
-    dummy = baker.make("dummy.ModelWithHistory", changed_by=user)
-
-    dummy.name = "Updated by first user"
-    dummy.save()
-
-    dummy._history_user = another_user
-    dummy.name = "Updated by second user"
-    dummy.save()
-
-    assert dummy.history.count() == 3
-    historical_records = list(dummy.history.all())
-    assert historical_records[0].history_user == another_user
-    assert historical_records[1].history_user == user
-    assert historical_records[2].history_user == user
 
 
 @override_settings(


### PR DESCRIPTION
I misread the documentation and thought I *had* to define this to track the user who changed the record. I also failed to remember the dozens of times I saw the user in the admin when looking at historical records of models. Minor brain fart.