### PR TITLE
:bookmark: bump version 0.17.0 -> 0.17.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.17.0
+current_version: 0.17.1
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.17.1]
+
 ### Removed
 
 - Removed use of `django.utils.itercompat` from templatetags in favor of `isinstance` check.
@@ -249,7 +251,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.17.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.17.1...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
@@ -274,3 +276,4 @@ Initial release!
 [0.16.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.16.0
 [0.16.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.16.1
 [0.17.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.17.0
+[0.17.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.17.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.17.0"
+current_version = "0.17.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.17.0"
+    assert __version__ == "0.17.1"


### PR DESCRIPTION
- `ad0582a`: [pre-commit.ci] pre-commit autoupdate (#116)
- `73a537e`: [pre-commit.ci] pre-commit autoupdate (#121)
- `ea30dc7`: [pre-commit.ci] pre-commit autoupdate (#123)
- `b576d03`: [pre-commit.ci] pre-commit autoupdate (#124)
- `1336788`: [pre-commit.ci] pre-commit autoupdate (#125)
- `fda62ef`: [pre-commit.ci] pre-commit autoupdate (#126)
- `d1dcd01`: [pre-commit.ci] pre-commit autoupdate (#127)
- `346c61c`: [pre-commit.ci] pre-commit autoupdate (#128)
- `9dabbac`: [pre-commit.ci] pre-commit autoupdate (#129)
- `2a1bf92`: :robot: [pre-commit.ci] pre-commit autoupdate (#130)
- `df30225`: :robot: [pre-commit.ci] pre-commit autoupdate (#131)
- `89c0810`: [pre-commit.ci] pre-commit autoupdate (#132)
- `ec1adf2`: [pre-commit.ci] pre-commit autoupdate (#133)
- `119fe3d`: [pre-commit.ci] pre-commit autoupdate (#134)
- `a5fc6bb`: :robot: [pre-commit.ci] pre-commit autoupdate (#135)
- `bbf23ec`: [pre-commit.ci] pre-commit autoupdate (#136)
- `5fac894`: remove deprecated `django.utils.itercompat` (#139)
- `fb8b410`: bump min Python version for `main` Django and add 5.2a1 (#138)