### PR TITLE
:tractor: Backports create_view_url logic

### DIFF
--- a/src/django_twc_toolbox/crud/templates/neapolitan/object_list.html
+++ b/src/django_twc_toolbox/crud/templates/neapolitan/object_list.html
@@ -7,10 +7,12 @@
 {% block content %}
   <div class="sm:flex sm:items-center">
     <h1 class="text-base font-semibold leading-6 text-gray-900 sm:flex-auto">{{ object_verbose_name_plural|capfirst }}</h1>
-    <div class="mt-4 sm:flex-none sm:mt-0 sm:ml-16">
-      <a class="block py-2 px-3 text-sm font-semibold text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
-         href="{{ create_view_url }}">Add a new {{ object_verbose_name }}</a>
-    </div>
+    {% if create_view_url %}
+      <div class="mt-4 sm:flex-none sm:mt-0 sm:ml-16">
+        <a class="block py-2 px-3 text-sm font-semibold text-center text-white bg-indigo-600 rounded-md shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+           href="{{ create_view_url }}">Add a new {{ object_verbose_name }}</a>
+      </div>
+    {% endif %}
   </div>
 
   {% partialdef object-list inline=True %}


### PR DESCRIPTION
Fixes #146 

This would clean up using Neapolitan for more read-only operations. 

Backport of https://github.com/carltongibson/neapolitan/blob/main/src/neapolitan/templates/neapolitan/object_list.html
