### PR TITLE
fix `CRUDView` rendering partial on htmx history-restore requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- `CRUDView.get_template_names` now returns the full document template instead of the `#object-list` partial on htmx history-restore requests (`HX-History-Restore-Request: true`), so the back button no longer renders a chrome-less, unstyled page on an htmx history-cache miss. ([#211](https://github.com/westerveltco/django-twc-toolbox/issues/211))
 - Silenced two mypy `[misc]` errors on `ReadOnlyStackedInline`/`ReadOnlyTabularInline` caused by a newer django-stubs changing the `InlineModelAdmin.get_readonly_fields` signature, which made it incompatible with the override in `ReadOnlyModelAdmin` across the two base classes.
 
 ## [0.18.0]

--- a/src/django_twc_toolbox/crud/views.py
+++ b/src/django_twc_toolbox/crud/views.py
@@ -220,7 +220,15 @@ class CRUDView(NeapolitanCRUDView):
         # only render the template partial if:
         # - it's the list view
         # - it's an HTMX request
+        # - it's not an HTMX history-restore request
         # - it's not a paginated request
+        #
+        # On an htmx history-cache miss, htmx re-requests the URL with both
+        # `HX-Request: true` and `HX-History-Restore-Request: true`, then swaps the
+        # response into `<body>`. If we returned the bare `#object-list` partial here,
+        # the user would get a chrome-less, unstyled page (no `<head>`, CSS, etc.).
+        # So a history-restore request is treated like a non-htmx request and gets the
+        # full document template.
         #
         # Right now, our custom templates do not have support for rendering template partials when
         # dealing with paginated lists. We could probably update it to add an `hx-target` to the
@@ -229,6 +237,7 @@ class CRUDView(NeapolitanCRUDView):
             self.role == Role.LIST
             and getattr(self.request, "htmx", False)
             and self.request.htmx
+            and not getattr(self.request.htmx, "history_restore_request", False)
             and not self.kwargs.get(self.page_kwarg, None)  # pyright: ignore[reportAny]
             and not self.request.GET.get(self.page_kwarg, None)
             and template_names is not None

--- a/tests/test_crud/test_views.py
+++ b/tests/test_crud/test_views.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.http import QueryDict
@@ -198,6 +200,26 @@ def test_get_template_names_no_htmx(rf):
     request = rf.get(Role.LIST.maybe_reverse(BookmarkView))
 
     view = BookmarkView(role=Role.LIST, **Role.LIST.extra_initkwargs())
+    view.setup(request)
+
+    template_names = view.get_template_names()
+
+    assert "neapolitan/object_list.html" in template_names
+    assert "neapolitan/object_list.html#object-list" not in template_names
+
+
+def test_get_template_names_htmx_history_restore(rf):
+    # On an htmx history-cache miss, htmx re-requests with both `HX-Request: true`
+    # and `HX-History-Restore-Request: true` and swaps the response into `<body>`,
+    # so we must return the full document template, not the `#object-list` partial.
+    request = rf.get(Role.LIST.maybe_reverse(BookmarkView))
+    request.htmx = SimpleNamespace(history_restore_request=True)
+
+    view = BookmarkView(
+        role=Role.LIST,
+        enable_template_partials=True,
+        **Role.LIST.extra_initkwargs(),
+    )
     view.setup(request)
 
     template_names = view.get_template_names()


### PR DESCRIPTION
## Problem

`CRUDView.get_template_names` decided between the full template and the `#object-list` partial based solely on `request.htmx`, ignoring htmx **history-restore** requests.

On an htmx history-cache *miss*, htmx re-requests the URL with both `HX-Request: true` **and** `HX-History-Restore-Request: true`, then swaps the response into `<body>`. Because the method only checked `request.htmx`, it returned the bare `#object-list` partial — a fragment with no `<head>`, CSS `<link>`, sidebar, or topbar. Swapped into `<body>`, the user saw an unstyled, chrome-less page (the classic "back button renders an unstyled page" report).

This was reproduced deterministically with prod-like CSS delivery (`DEBUG=False`, Vite manifest + tailwind `<link>`), so it's a real production bug, not a dev-server artifact or bfcache.

## Fix

In `get_template_names`, treat a history-restore request like a non-htmx request — skip the partial suffix when `request.htmx.history_restore_request` is true, so history-restore gets the full document template while ordinary htmx filter/navigation requests still get the `#object-list` partial. `getattr` with a `False` default keeps it safe when `request.htmx` is a plain bool.

## Tests

Added `test_get_template_names_htmx_history_restore` asserting the full template (not the partial) is returned on a history-restore request even with `enable_template_partials=True`. Full crud suite passes (`74 passed, 2 skipped`).

## Follow-up

Once released, the local workaround subclass in `lease` (added in westerveltco/lease#2029) can be removed and its pin bumped. Tracked by westerveltco/lease#2048.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
