### PR TITLE
fix mypy incompatible `get_readonly_fields` errors on read-only inlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Silenced two mypy `[misc]` errors on `ReadOnlyStackedInline`/`ReadOnlyTabularInline` caused by a newer django-stubs changing the `InlineModelAdmin.get_readonly_fields` signature, which made it incompatible with the override in `ReadOnlyModelAdmin` across the two base classes.
+
 ## [0.18.0]
 
 ### Changed

--- a/src/django_twc_toolbox/admin.py
+++ b/src/django_twc_toolbox/admin.py
@@ -42,13 +42,13 @@ class ReadOnlyModelAdmin(
         return False
 
 
-class ReadOnlyStackedInline(  # pyright: ignore[reportUnsafeMultipleInheritance]
+class ReadOnlyStackedInline(  # type: ignore[misc]  # pyright: ignore[reportUnsafeMultipleInheritance]
     ReadOnlyModelAdmin[ChildModelT, ParentModelT],
     admin.StackedInline[ChildModelT, ParentModelT],
 ): ...
 
 
-class ReadOnlyTabularInline(  # pyright: ignore[reportUnsafeMultipleInheritance]
+class ReadOnlyTabularInline(  # type: ignore[misc]  # pyright: ignore[reportUnsafeMultipleInheritance]
     ReadOnlyModelAdmin[ChildModelT, ParentModelT],
     admin.TabularInline[ChildModelT, ParentModelT],
 ): ...


### PR DESCRIPTION
## Problem

The `types` (mypy) CI job started failing with two errors on `src/django_twc_toolbox/admin.py`:

```
admin.py:45: error: Definition of "get_readonly_fields" in base class "ReadOnlyModelAdmin" is incompatible with definition in base class "InlineModelAdmin"  [misc]
admin.py:51: error: (same)
```

This is **dependency drift, not a code change**. `main` last ran CI on 2026-05-20 and passed; nothing in `admin.py` has changed since #93. A newer **django-stubs** (the `types` job installs it unpinned) changed the signature of `InlineModelAdmin.get_readonly_fields`, which made the override in `ReadOnlyModelAdmin` incompatible across the two base classes of `ReadOnlyStackedInline`/`ReadOnlyTabularInline`.

Surfaced on #212, but it will hit every PR (and the next pre-commit-ci run) until fixed.

## Fix

Add a targeted `# type: ignore[misc]` on the two class definitions, alongside the existing `# pyright: ignore[reportUnsafeMultipleInheritance]`. This matches the per-line ignore pattern already used throughout this file (e.g. the `# type: ignore[override]` on the `has_*_permission` methods).

## Verification

`mypy .` over the whole package now reports `Success: no issues found in 32 source files`. `warn_unused_ignores = true` is on, so the ignores are confirmed necessary (not stale) against the current stubs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)