### PR TITLE
Release v0.18.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.27
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.18.0
+current_version: 0.18.1
 django_versions:
 - '4.2'
 - '5.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.18.1]
+
 ### Fixed
 
 - `CRUDView.get_template_names` now returns the full document template instead of the `#object-list` partial on htmx history-restore requests (`HX-History-Restore-Request: true`), so the back button no longer renders a chrome-less, unstyled page on an htmx history-cache miss. ([#211](https://github.com/westerveltco/django-twc-toolbox/issues/211))
@@ -262,7 +264,7 @@ Initial release!
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.18.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-twc-toolbox/compare/v0.18.1...HEAD
 [0.2.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.1
 [0.2.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.2.0
 [0.1.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.1.1
@@ -289,3 +291,4 @@ Initial release!
 [0.17.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.17.0
 [0.17.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.17.1
 [0.18.0]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.18.0
+[0.18.1]: https://github.com/westerveltco/django-twc-toolbox/releases/tag/v0.18.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,8 @@ When it comes time to cut a new release, follow these steps:
 
    However, the branch name is not *super* important, as long as it is not `main`.
 
+   The remaining instructions assume you have an activated virtual environment with the development dependencies installed (see [CONTRIBUTING.md](CONTRIBUTING.md#setup)).
+
 2. Update the version number across the project using the `bumpver` tool. See [this section](#choosing-the-next-version-number) for more details about choosing the correct version number.
 
    The `pyproject.toml` in the base of the repository contains a `[tool.bumpver]` section that configures the `bumpver` tool to update the version number wherever it needs to be updated and to create a commit with the appropriate commit message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ stubPath = "src/stubs"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.18.0"
+current_version = "0.18.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/django_twc_toolbox/__init__.py
+++ b/src/django_twc_toolbox/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_twc_toolbox import __version__
 
 
 def test_version():
-    assert __version__ == "0.18.0"
+    assert __version__ == "0.18.1"


### PR DESCRIPTION
Release v0.18.1.

## Changes

### Fixed

- `CRUDView.get_template_names` now returns the full document template instead of the `#object-list` partial on htmx history-restore requests (`HX-History-Restore-Request: true`), so the back button no longer renders a chrome-less, unstyled page on an htmx history-cache miss. (#211)
- Silenced two mypy `[misc]` errors on `ReadOnlyStackedInline`/`ReadOnlyTabularInline` caused by a newer django-stubs changing the `InlineModelAdmin.get_readonly_fields` signature, which made it incompatible with the override in `ReadOnlyModelAdmin` across the two base classes.

## Release steps

- [x] Version bumped `0.18.0` -> `0.18.1` via `bumpver`
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)