### PR TITLE
chore: enable core Ruff rule groups

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -48,11 +48,8 @@ def should_skip(python: str, django: str) -> bool:
         # Django 5.1 requires Python 3.10+
         return True
 
-    if django == DJ50 and version(python) < version(PY310):
-        # Django 5.0 requires Python 3.10+
-        return True
-
-    return False
+    # Django 5.0 requires Python 3.10+
+    return django == DJ50 and version(python) < version(PY310)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,13 +219,26 @@ quote-style = "double"
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
+fixable = ["ALL"]
 ignore = ["E501", "E741"]  # temporary
 select = [
+  "A",  # flake8-builtins
   "B",  # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "DJ",  # flake8-django
+  "DTZ",  # flake8-datetimez
   "E",  # Pycodestyle
   "F",  # Pyflakes
+  "G",  # flake8-logging-format
   "I",  # isort
+  "LOG",  # flake8-logging
+  "PIE",  # flake8-pie
+  "PT",  # flake8-pytest-style
+  "RET",  # flake8-return
+  "RUF100",  # unused noqa
+  "S",  # flake8-bandit
+  "SIM",  # flake8-simplify
+  "T20",  # flake8-print
   "UP"  # pyupgrade
 ]
 unfixable = []
@@ -236,8 +249,27 @@ known-first-party = ["django_twc_toolbox"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+# Sphinx expects this setting name.
+"docs/conf.py" = ["A001"]
+# Stubs mirror third-party APIs.
+"src/stubs/**/*.pyi" = ["A002"]
+# Tests can use assertions, sample secrets, dummy models, and existing pytest style.
+"tests/**/*" = [
+  "A001",
+  "C401",
+  "DJ008",
+  "PLR2004",
+  "PT006",
+  "PT011",
+  "PT014",
+  "PT030",
+  "S101",
+  "S105",
+  "SIM108",
+  "SIM117",
+  "SIM118",
+  "TID252"
+]
 
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.

--- a/src/django_twc_toolbox/crud/templatetags/neapolitan.py
+++ b/src/django_twc_toolbox/crud/templatetags/neapolitan.py
@@ -13,8 +13,8 @@ from django_twc_toolbox.crud.views import CRUDView
 register = template.Library()
 
 
-def action_links(view: CRUDView, object: models.Model):
-    actions = {
+def action_links(view: CRUDView, object: models.Model):  # noqa: A002
+    return {
         "detail": {
             "url": Role.DETAIL.maybe_reverse(view, object),
             "text": "View",
@@ -28,11 +28,10 @@ def action_links(view: CRUDView, object: models.Model):
             "text": "Delete",
         },
     }
-    return actions
 
 
 @register.inclusion_tag("neapolitan/partial/detail.html")
-def object_detail(object: models.Model, view: CRUDView):
+def object_detail(object: models.Model, view: CRUDView):  # noqa: A002
     """
     Renders a detail view of an object with the given fields.
 
@@ -46,7 +45,7 @@ def object_detail(object: models.Model, view: CRUDView):
 
     fields = view.get_fields()
 
-    def iter() -> Generator[tuple[str, str], None, None]:
+    def iter() -> Generator[tuple[str, str], None, None]:  # noqa: A001
         for f in fields:
             mf = object._meta.get_field(f)
             yield (cast(str, mf.verbose_name), str(getattr(object, f)))  # type: ignore[union-attr]
@@ -75,7 +74,7 @@ def object_list(objects: Sequence[models.Model], view: CRUDView):
             "fields": [{"name": f, "value": str(getattr(object, f))} for f in fields],
             "actions": action_links(view, object),
         }
-        for object in objects
+        for object in objects  # noqa: A001
     ]
 
     return {

--- a/src/django_twc_toolbox/management/commands/copy_template.py
+++ b/src/django_twc_toolbox/management/commands/copy_template.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from shutil import copy2
 
@@ -32,13 +33,15 @@ from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template import loader
 
+logger = logging.getLogger(__name__)
+
 
 def get_template_absolute_path(template_path):
     try:
         template = loader.get_template(template_path)
         return template.origin.name  # type: ignore[attr-defined]
-    except Exception as e:
-        print(f"Error occurred while getting template path: {e}")
+    except Exception:
+        logger.exception("Error occurred while getting template path")
         return None
 
 
@@ -50,7 +53,6 @@ class Command(BaseCommand):
         parser.add_argument("destination", type=str, nargs="?")
 
     def handle(self, *args, **options):
-        print(options)
         # 1. extract the options
         source = options["source"]
         destination = options.get("destination")

--- a/src/django_twc_toolbox/models.py
+++ b/src/django_twc_toolbox/models.py
@@ -55,7 +55,7 @@ class TimeStamped(models.Model):
         modified field is updated even if it is not given as
         a parameter to the update field argument.
         """
-        update_fields = kwargs.get("update_fields", None)
+        update_fields = kwargs.get("update_fields")
         if update_fields:
             kwargs["update_fields"] = set(update_fields).union({"updated_at"})
 

--- a/src/django_twc_toolbox/numbers.py
+++ b/src/django_twc_toolbox/numbers.py
@@ -70,5 +70,4 @@ def format_number_no_round(number: T, *, decimal_places: int = 2) -> str | Decim
 
     if isinstance(number, (float | str)):
         return formatted_str
-    else:
-        return Decimal(formatted_str)
+    return Decimal(formatted_str)

--- a/src/django_twc_toolbox/paginator.py
+++ b/src/django_twc_toolbox/paginator.py
@@ -35,7 +35,7 @@ class DatePaginator(Generic[_T], Paginator[_T]):
         self.date_field = date_field
         self.page_date_range = page_date_range
 
-        if kwargs.get("orphans", None):
+        if kwargs.get("orphans"):
             warnings.warn(
                 "The `orphans` parameter is not applicable for DatePaginator and will be ignored.",
                 UserWarning,

--- a/src/stubs/neapolitan/views.pyi
+++ b/src/stubs/neapolitan/views.pyi
@@ -1,5 +1,4 @@
 # pyright: reportDeprecated=false
-# ruff: noqa: UP006
 import builtins
 import enum
 from collections.abc import Callable


### PR DESCRIPTION
## Summary
- Enable the shared core Ruff rule groups for `django-twc-toolbox`.
- Apply trivial fixes and targeted ignores so Ruff passes.

## Validation
- `uv run ruff check .; just lint`

## Why these rules

The goal here is a boring, broadly useful Ruff baseline for Python/Django projects: catch correctness issues, framework-specific mistakes, test quality problems, security footguns, naive datetime usage, logging problems, and low-noise readability issues without enabling higher-churn families like `ANN`, `ARG`, full `PL`, full `RUF`, or `TRY`.

| Ruff code | What it is | Why it is a good default |
|---|---|---|
| `E` | `pycodestyle` errors | A small baseline for Python style errors that are not handled purely by formatting. These are familiar, low-surprise checks. |
| `F` | `Pyflakes` | High-signal correctness checks: undefined names, unused imports, duplicate definitions, invalid string formatting, and other issues that are often real bugs. |
| `I` | `isort` import sorting | Keeps import blocks deterministic and easy to review. This removes one common source of mechanical diff noise. |
| `B` | `flake8-bugbear` | Catches practical Python footguns: mutable defaults, problematic exception handling, loop-binding mistakes, useless expressions, and similar bug-prone patterns. |
| `UP` | `pyupgrade` | Keeps code aligned with the repository's target Python version and removes obsolete compatibility patterns. This helps the codebase stay consistent as Python versions move forward. |
| `DJ` | `flake8-django` | Adds Django-specific checks for models, forms, and framework conventions. These catch issues general Python linters cannot see, such as risky `ModelForm` exposure or model definition problems. |
| `PT` | `flake8-pytest-style` | Keeps tests idiomatic and consistent: parametrization shape, `pytest.raises` usage, fixture style, and pytest-vs-unittest assertion patterns. |
| `S` | Bandit security rules | Provides a baseline for common security-sensitive mistakes: suspicious `mark_safe`, hardcoded secrets, weak randomness, subprocess hazards, unsafe temp files, and raw SQL-ish patterns. It is not a full security review, but it is a useful default safety net. |
| `DTZ` | timezone-aware datetime rules | Especially useful in Django apps, where naive datetimes can become production bugs. These rules encourage explicit timezone-aware datetime usage. |
| `G` | `flake8-logging-format` | Enforces lazy logging formatting instead of f-strings, `.format()`, or `%` interpolation before the log call. This preserves normal logging behavior and avoids doing formatting work when the message is not emitted. |
| `LOG` | logging convention rules | Catches broader logging issues such as root logger usage, weak exception logging, redundant exception text, and logger setup problems. Good logging conventions improve diagnostics without changing application behavior. |
| `T20` | `print()` checks | In application and package code, stdout is usually the wrong interface for diagnostics. This nudges code toward logging, explicit CLI output, test assertions, or deletion. |
| `A` | builtin shadowing | Flags names like `id`, `type`, `list`, `filter`, and `input`. Avoiding builtin shadowing keeps code clearer and avoids subtle surprises when those builtins are needed later. |
| `C4` | comprehension cleanup | Catches redundant or inefficient comprehension patterns, such as unnecessary intermediate lists. These are usually straightforward readability/performance improvements. |
| `PIE` | `flake8-pie` small correctness/cleanup rules | A collection of low-noise checks for minor correctness and maintainability issues, such as unnecessary kwargs expansion, duplicate enum values, and repeated `startswith`/`endswith` patterns. |
| `RET` | return-path cleanup | Simplifies control flow by catching unnecessary `else` after `return`, redundant assignment-before-return, and implicit return patterns. The result is easier-to-scan functions. |
| `SIM` | `flake8-simplify` | Finds simpler equivalent forms for common conditionals and expressions, such as `x in dict.keys()`, collapsible `if` statements, or redundant boolean logic. Useful when the simplification is obvious and low risk. |
| `RUF100` | unused `noqa` comments | Keeps suppressions honest. Dead `noqa` comments make it harder to tell which suppressions are still intentional and can hide future issues. |
